### PR TITLE
Fix for conflict with imports of other resources

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,10 @@ module.exports = function() {
             return url;
           }
           var resourceAbsUrl = path.relative(file.base, path.resolve(path.dirname(file.path), url));
+          
+          // only css file are imported, we leave all other file imports (eot, woff, svg,...) as they are.
+          if (path.extname(resourceAbsUrl) != 'css') return url;
+                    
           return path.relative(destDir, resourceAbsUrl);
         }))
         .toString();


### PR DESCRIPTION
I've added a line that ensures that the inlining of extern resources only occurs for the CSS files, and also changed 'const' with 'var' to be compliant with the JS strict mode.
Note : in my usage I only had CSS to render inline, maybe other resources should be considered.

Anyway, thanks for bringing up this module :-) 
