### PR TITLE
remove gulp-util #9

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,5 @@
 {
     "parser": "espree",
-    "ecmaFeatures": {},
     "rules": {
         "no-alert": "off",
         "no-array-constructor": "off",

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-var gutil = require('gulp-util'),
+var PluginError = require('plugin-error'),
   path = require('path'),
   rework = require('rework'),
   reworkImporter = require('rework-importer'),
@@ -12,7 +12,7 @@ module.exports = function() {
 
   return through.obj(function(file, enc, cb) {
     if (file.isStream()) {
-      this.emit('error', new gutil.PluginError(PLUGIN_NAME, 'Streaming not supported'));
+      this.emit('error', new PluginError(PLUGIN_NAME, 'Streaming not supported'));
       return cb();
     }
 
@@ -45,7 +45,7 @@ module.exports = function() {
         }))
         .toString();
     } catch(err) {
-      this.emit('error', new gutil.PluginError(PLUGIN_NAME, err));
+      this.emit('error', new PluginError(PLUGIN_NAME, err));
       return cb();
     }
 

--- a/package.json
+++ b/package.json
@@ -21,15 +21,16 @@
   ],
   "main": "./index.js",
   "dependencies": {
-    "gulp-util": "~2.2.14",
-    "through2": "~0.4.1",
+    "plugin-error": "~1.0.1",
+    "rework": "~0.20.2",
     "rework-importer": "~0.4.0",
-    "rework": "~0.20.2"
+    "through2": "~0.4.1",
+    "vinyl": "~2.1.0"
   },
   "devDependencies": {
-    "chai": "^3.5.0",
-    "eslint": "^3.7.1",
-    "mocha": "^3.1.0"
+    "chai": "^4.1.2",
+    "eslint": "^4.19.0",
+    "mocha": "^5.0.4"
   },
   "scripts": {
     "test": "eslint index.js && mocha --reporter spec test/main"

--- a/test/main.js
+++ b/test/main.js
@@ -1,6 +1,6 @@
 var should = require('chai').should(),
     importCss = require('../'),
-    gutil = require('gulp-util'),
+    Vinyl = require('vinyl'),
     fs = require('fs'),
     pj = require('path').join;
 
@@ -8,7 +8,7 @@ function createVinyl(lessFileName, contents) {
   var base = pj(__dirname, 'fixtures');
   var filePath = pj(base, lessFileName);
 
-  return new gutil.File({
+  return new Vinyl({
     cwd: __dirname,
     base: base,
     path: filePath,


### PR DESCRIPTION
gulp-util was removed per gulps instructions. The following were replaced:

`gutil.File` => is now `vinyl`
`gutil.PluginError` => is now `plugin-error`

Additional updates included is updating `chai`, `eslint`, and `mocha` to current versions. As well as the removal of `ecmaFeatures` from `.eslintrc` as the configuration is no longer a valid option.

Unit test is passing.